### PR TITLE
Replace package.json proxying with explicit API URL

### DIFF
--- a/.procfiles/Procfile.api
+++ b/.procfiles/Procfile.api
@@ -1,0 +1,2 @@
+web: bundle exec rails s -p $PORT -b 0.0.0.0
+release: bundle exec rake db:migrate

--- a/.procfiles/Procfile.client
+++ b/.procfiles/Procfile.client
@@ -1,0 +1,1 @@
+web: npm start

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: bundle exec rails s -p $PORT

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,11 +8,10 @@
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
     "react-fontawesome": "1.5.0",
-    "react-router-dom":"4.3.1"
-  },
-  "devDependencies": {
+    "react-router-dom":"4.3.1",
     "react-scripts": "2.0.5"
   },
+  "devDependencies": {},
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,6 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:3000",
   "dependencies": {
     "axios": "^0.18.0",
     "react": "^16.5.2",

--- a/frontend/src/components/AdminControls/User.js
+++ b/frontend/src/components/AdminControls/User.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import axios from "axios";
+import apiClient from "../../lib/apiClient";
 
 class User extends Component {
   constructor(props) {
@@ -21,7 +21,7 @@ class User extends Component {
   }
 
   componentDidMount() {
-    axios.get('/users/' + this.props.match.params.id)
+    apiClient.get('/user/' + this.props.match.params.id)
     .then(response => {
       this.setState({ 
         user: response.data,
@@ -37,7 +37,7 @@ class User extends Component {
 
   destroyUser = (event) => {
     console.log("deleting user");
-    axios.delete('/users/' + this.state.user.id)
+    apiClient.delete('/user/' + this.state.user.id)
     .then(response => {
       this.setState({ user: "this user no longer exists"})
     })
@@ -46,7 +46,7 @@ class User extends Component {
 
   updateUser = (event) => {
     console.log("updating user");
-    axios.patch('/users/' + this.state.user.id, {
+    apiClient.patch('/user/' + this.state.user.id, {
         email: this.state.email,
         user_name: this.state.user_name,
         first_name: this.state.first_name,

--- a/frontend/src/components/AdminControls/UsersAll.js
+++ b/frontend/src/components/AdminControls/UsersAll.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from "react-router-dom";
-import axios from "axios";
+import apiClient from "../../lib/apiClient";
 
 class UsersAll extends Component {
   constructor(props) {
@@ -11,7 +11,7 @@ class UsersAll extends Component {
   }
 
   componentDidMount() {
-    axios.get('/users')
+    apiClient.get('/user')
     .then(response => {
       this.setState({ users: response.data.users})
       console.log("data", this.state.users);

--- a/frontend/src/components/SignUp/SignUp.js
+++ b/frontend/src/components/SignUp/SignUp.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import axios from 'axios';
+import apiClient from '../../lib/apiClient';
 
 class SignUp extends Component {
   constructor(props) {
@@ -21,7 +21,7 @@ class SignUp extends Component {
   }
 
   signUp = (event) => {
-    axios.post('/users', {
+    apiClient.post('/user', {
         email: this.state.email,
         password: this.state.password,
         password_confirmation: this.state.password_confirmation,

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,0 +1,11 @@
+import axios from "axios";
+
+let baseURL = process.env.REACT_APP_API_URL || "http://localhost:3000"
+
+let apiClient = axios.create({
+    baseURL: baseURL
+});
+
+// TODO: add methods to wrap API endpoints
+
+module.exports = apiClient;

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -8,4 +8,4 @@ let apiClient = axios.create({
 
 // TODO: add methods to wrap API endpoints
 
-module.exports = apiClient;
+export default apiClient;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "proxy-package.json",
+  "name": "rescue-leftover-cuisine",
   "engines": {
     "node": "8"
   },


### PR DESCRIPTION
### Describe The Problem Being Solved:

At present, the app assumes that it will be deployed with the API and client in the same container. This isn't necessarily optimal, and in particular might make it difficult to debug and separate out frontend issues from backend ones.

This PR removes that assumption and preps the app for deployment to Heroku as two separate apps, a Rails API and a React frontend. They're using the multi-Procfile buildpack from Heroku, which allows us to generate two apps with different codebases from a single repo.

In particular, this replaces raw `axios` calls by wrapping them in an `apiClient`, which fills in the base URL from the environment or defaults to localhost. I'd love to fill out this apiClient in the future, so that instead of calling `axios.get("/user")`, we call `apiClient.getUser()`, and handle axios at that layer.

### Checklist For Reviewer
* [ ] Code formatting/static analysis: is the code formatted properly? Does a linter/other form of static analysis reveal any issues? Does the code have appropriately low cyclomatic complexity?
* [ ] Code architecture: concerns are separated, code follows single-responsibility principle, code utilizes OOP, DRY code.
* [ ] Coding best practices: code avoids hard-coded variables, inefficient computations, reinventing the wheel when using frameworks. Code is well-commented and generally readable.
* [ ] Non-functional requirements: Code has accompanying tests (if using TDD). Programmer can easily explain decisions to reviewers. 