### PR TITLE
Add simple CORS to backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'puma', '~> 3.11'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Use .env files to manage variables in dev

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
     pg (1.1.4)
     puma (3.12.0)
     rack (2.0.6)
+    rack-cors (1.0.2)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.2)
@@ -180,6 +181,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
+  rack-cors
   rails (~> 5.2.2)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,5 +34,13 @@ module Rlc
 
     # Load files from the lib directory into the namespace
     config.autoload_paths << Rails.root.join('lib')
+
+    # Handle CORS before doing anything else, especially authentication.
+    config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :put, :patch, :delete, :options]
+      end
+    end
   end
 end


### PR DESCRIPTION
### Ticket Number:

#139

### Describe The Problem Being Solved:

Whenever a site is hooked up to the internet, security becomes a concern. Browser makers and site developers have recognized that certain kinds of communication are more open to abuse, so they've come up with ways to help mitigate risks in this area.

One area of interest to us is Cross-Origin Resource Sharing (CORS), which is when a browser is visiting a website on a particular server, and that website asks the browser to fetch a resource from a different server. The most obvious example of this is when you're visiting a site (hosted at, say, tde.org), and the JavaScript frontend makes an API request to another server (like api.tde.org). Since these are different URLs (or "origins"), this is a "cross-origin request."

In many cases, the API developers will want to protect themselves by only allowing cross-origin requests from specific sites. For example, at api.tde.org, we want to allow API requests to come from tde.org, but not hax0rs.com. In particular, we want to prevent write access, so requests with methods like `POST`, `PUT`, or `DELETE`.

To facilitate this, browser-makers will actually issue two requests when a JavaScript application submits a cross-origin write request. First, it will make a CORS request, and the server will return certain headers to describe if the real request will be allowed and how it should be formatted. Then, if it's allowed to, the browser will issue the actual request.

So if I hit `POST https://api.tde.org/api/v1/user`, the browser will actually first make an `OPTIONS` request, and the server will respond by telling it whether the URL the request is coming from is allowed, along with which headers and such are permitted. If this check comes back OK, the browser will then issue the POST request.

This PR adds a gem and some configuration to support a basic CORS configuration, which will be necessary when the site is deployed to Heroku. Since the api will be hosted at one URL (rlc-api.herokuapp.com) and the frontend at another (rlc.herokuapp.com), the API needs to allow requests from the frontend server. In this PR, I've set it up so we'll allow requests from _any_ URL. We can come back later and configure it more tightly when we get closer to finishing the project.

### Checklist For Reviewer
* [ ] Code formatting/static analysis: is the code formatted properly? Does a linter/other form of static analysis reveal any issues? Does the code have appropriately low cyclomatic complexity?
* [ ] Code architecture: concerns are separated, code follows single-responsibility principle, code utilizes OOP, DRY code.
* [ ] Coding best practices: code avoids hard-coded variables, inefficient computations, reinventing the wheel when using frameworks. Code is well-commented and generally readable.
* [ ] Non-functional requirements: Code has accompanying tests (if using TDD). Programmer can easily explain decisions to reviewers. 