### PR TITLE
adding icon8 link to footer

### DIFF
--- a/frontend/src/components/Footer/Footer.js
+++ b/frontend/src/components/Footer/Footer.js
@@ -29,7 +29,7 @@ class Footer extends Component {
              <div className="col-md-4 designBySection">
                <span>Designed by </span>
                <span className="designByCo">Fluid Designs</span>
-               <p>App icons by <a href="https://icons8.com/" target="_blank">icons8.</a></p>
+               <p>App icons by <a href="https://icons8.com/" target="_blank" rel="noopener noreferrer">icons8.</a></p>
             </div>
 
             <div className="col-md-4"></div>

--- a/frontend/src/components/Footer/Footer.js
+++ b/frontend/src/components/Footer/Footer.js
@@ -29,7 +29,9 @@ class Footer extends Component {
              <div className="col-md-4 designBySection">
                <span>Designed by </span>
                <span className="designByCo">Fluid Designs</span>
+               <p>App icons by <a href="https://icons8.com/" target="_blank">icons8.</a></p>
             </div>
+
             <div className="col-md-4"></div>
           </div>
         </div>


### PR DESCRIPTION
### Ticket Number: 172



### Describe The Problem Being Solved:
Adding link to icon8 text in license disclaimer at bottom of footer. Link opens in new browser tab.
<img width="1208" alt="screen shot 2019-03-04 at 8 40 07 pm" src="https://user-images.githubusercontent.com/24326590/53777107-ce284f00-3ebd-11e9-92f4-67f43c0e8bde.png">



### Checklist For Submitter

* [-] I have documented all new functionality
* [ X] I have screenshotted new UI changes and attached them to this PR

### Checklist For Reviewer
* [ ] Code formatting/static analysis: is the code formatted properly? Does a linter/other form of static analysis reveal any issues? Does the code have appropriately low cyclomatic complexity?
* [ ] Code architecture: concerns are separated, code follows single-responsibility principle, code utilizes OOP, DRY code.
* [ ] Coding best practices: code avoids hard-coded variables, inefficient computations, reinventing the wheel when using frameworks. Code is well-commented and generally readable.
* [ ] Non-functional requirements: Code has accompanying tests (if using TDD). Programmer can easily explain decisions to reviewers. 