### PR TITLE
Feature/182/fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
 FROM ruby:2.5.3
 
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev sudo net-tools && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
-    export NVM_DIR="$HOME/.nvm" && \
-    . $NVM_DIR/nvm.sh && \
-    nvm install 8.11.4
-    # install yarn
-    # curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
-    # echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-    # sudo apt-get update && sudo apt-get install yarn
+    curl -sSL "https://nodejs.org/dist/v8.11.4/node-v8.11.4-linux-x64.tar.gz" | tar -C /usr --strip-components=1 -xz
 
 RUN mkdir -p /app/frontend
 ENV PATH=/app/bin:$PATH RAILS_ENV=development

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 FROM ruby:2.5.3
+
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev sudo net-tools && \
-    # install node
-    curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && \
-    sudo apt-get install -y nodejs && \
+    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash && \
+    export NVM_DIR="$HOME/.nvm" && \
+    . $NVM_DIR/nvm.sh && \
+    nvm install 8.11.4
     # install yarn
-    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
-    sudo apt-get update && sudo apt-get install yarn
+    # curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - && \
+    # echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list && \
+    # sudo apt-get update && sudo apt-get install yarn
 
 RUN mkdir -p /app/frontend
 ENV PATH=/app/bin:$PATH RAILS_ENV=development


### PR DESCRIPTION
### Describe The Problem Being Solved:

In #223, we add an npmrc to the project that forces you to use a specific version of npm. This will prevent us from generating spurious updates to package-lock.json, which could cause instability in the project over time.

However, the npm/node versions in the Docker image wasn't pinned to the correct version, so the Docker image wouldn't properly come up. This fixes that by installing the node 8.11.4 explicitly, which should also contain the correct npm version.