### PR TITLE
Feature/213/button color default

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,3 +6,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+button {
+  background-color: white;
+}


### PR DESCRIPTION
### Ticket Number: 213



### Describe The Problem Being Solved:
On windows computer, buttons without a background-color specified were defaulting to grey. I changed this to white in the index.css to fix the default throughout the app



### Checklist For Submitter

* [X] I have documented all new functionality
* [X] I have screenshotted new UI changes and attached them to this PR

![image](https://user-images.githubusercontent.com/30510953/58296086-e6f72100-7d97-11e9-9c21-6727ef3e974d.png)

![image](https://user-images.githubusercontent.com/30510953/58296098-f7a79700-7d97-11e9-8ae6-c7ad176e5506.png)

