### PR TITLE
Move package installation into build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -qq && apt-get install -y build-essential libpq-dev sudo net-
 RUN mkdir -p /app/frontend
 ENV PATH=/app/bin:$PATH RAILS_ENV=development
 WORKDIR /app
-COPY Gemfile /app/Gemfile
-COPY Gemfile.lock /app/Gemfile.lock
-RUN gem install bundler -v 1.17.3
 COPY . /app
+RUN gem install bundler -v 1.17.3 && \
+    bundle install && \
+    cd frontend && npm install

--- a/README.md
+++ b/README.md
@@ -56,17 +56,15 @@ This will build your `db`, and `web` images
 
 ## Running rlc-web containers
 
-1. You will need an empty `Gemfile.lock` in order to build your `Dockerfile`. You can delete and create a new blank dockerfile by running the following commands in the rails app root directory:
-
+1. Run following command to start your containers:
 ```
-rm -rf Gemfile.lock
-touch Gemfile.lock
+docker-compose up
 ```
 
-2. Then, run following command to your containers:
-```
-docker-compose up -d
-```
+## Stopping rlc-web containers
+You can try to stop the running containers from the running `docker-compose up` session by pressing CTRL-C.
+
+You can delete the containers (resetting the database) entire by running `docker-compose down`.
 
 ## Staging
 You can preview what the applicaton will look a production-ish environment by merging changes into the `staging` branch:
@@ -89,6 +87,14 @@ Sometimes issues will come up with your Docker instance than cannot be solved wi
 3. Remove all images: `docker rmi $(docker images -q)`
     * If you receive the message `"docker rmi" requires at least 1 argument.` it means that there are no downloaded images; it is safe to proceed.
 4. Download images and rebuild containers: `docker-compose up`
+
+## Dependencies
+
+For icons throughout the site, we use [icons8](https://icons8.com/).
+
+We use React on the frontend, employing Bootstrap and Reactstrap for styling.
+
+We use Ruby on Rails in API mode on the backend, with Devise for authentication.
 
 ## Project directory structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "5432"
   web:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle install && cd frontend && npm install && cd .. && rails db:create && rails db:migrate && rails db:seed && foreman start -f Procfile.dev"
+    command: bash -c "rm -f tmp/pids/server.pid && rails db:create && rails db:migrate && rails db:seed && foreman start -f Procfile.dev"
     volumes:
       - .:/app
     ports:


### PR DESCRIPTION
This adds some stuff to the readme, but primarily it moves npm install and bundle install into the docker build step. This will speed up running the project locally, as dependencies don't need to be reinstalled each time.