### PR TITLE
Use a blank volume for node_modules to prevent installation issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 version: '3'
+volumes:
+  node_modules:
 services:
   db:
     image: postgres
@@ -9,6 +11,7 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && rails db:create && rails db:migrate && rails db:seed && foreman start -f Procfile.dev"
     volumes:
       - .:/app
+      - node_modules:/app/frontend/node_modules/
     ports:
       - "3000:3000"
       - "5000:5000"


### PR DESCRIPTION
### Describe The Problem Being Solved:

We used to do `bundle install` and `npm install` in the run step of building the project, so every time you ran the app (`docker-compose up`), you'd have to reinstall dependencies. This was time-consuming and annoying.

We changed this a few weeks back to install dependencies in the build step. This helps cut down on build times. However, when building the app from scratch, this causes volume issues where the Node dependencies installed during the build step get overwritten by the dependencies on your local filesystem (in `frontend/node_modules`), which aren't complete. To fix this, you have to shell into the container and run `npm install` a couple more times.

This PR fixes that by setting up a `node_modules` volume using docker-compose. This way, when we run `docker-compose build`, the dependencies get placed on this volume instead of directly inside the container. When we `docker-compose up`, it reuses this volume in place of the local directory.

cc @H12