### PR TITLE
Fix toggling of search instructions

### DIFF
--- a/frontend/src/components/MainSearch/MainSearch.js
+++ b/frontend/src/components/MainSearch/MainSearch.js
@@ -9,7 +9,7 @@ class MainSearch extends Component {
     this.state = {
       searchTerm: '',
       error: '',
-      show: false,
+      showInstructions: false,
     };
 
     this.handleChange = this.handleChange.bind(this);
@@ -21,7 +21,7 @@ class MainSearch extends Component {
     const cookies = new Cookies();
     if (cookies.get('rlc') !== 'visited') {
       this.setState({
-        show: true,
+        showInstructions: true,
       });
       cookies.set('rlc', 'visited', { path: '/' });
     }
@@ -58,7 +58,7 @@ class MainSearch extends Component {
   }
 
   togglePanel() {
-    this.setState(prevState => ({ open: !prevState.open }));
+    this.setState(prevState => ({ showInstructions: !prevState.showInstructions }));
   }
 
   renderChevronButton() {
@@ -75,7 +75,7 @@ class MainSearch extends Component {
     );
   }
 
-  renderSearchInstructions() {
+  renderInstructions() {
     return (
       <div className="searchInstructions">
         <p>
@@ -91,7 +91,7 @@ class MainSearch extends Component {
   }
 
   render() {
-    const { error, show } = this.state;
+    const { error, showInstructions } = this.state;
 
     return (
       <div className="mainSearch container-fluid">
@@ -116,7 +116,7 @@ class MainSearch extends Component {
                     </button>
                   </div>
                   <div>
-                    { show ? this.renderSearchInstructions() : this.renderChevronButton() }
+                    { showInstructions ? this.renderInstructions() : this.renderChevronButton() }
                   </div>
                 </div>
               </form>


### PR DESCRIPTION
### Describe The Problem Being Solved:

I was checking the site to make sure it was ready to demo on Monday, and realized that you could no longer toggle the search instructions. This was due to the state being renamed to `show`, but it wasn't changed in the `togglePanel` method. I fixed that.

I also renamed the state variable to `showInstructions` to be more clear, and renamed the render function to `renderInstructions`, which helped it all fit in one ternary line.
