### PR TITLE
Only get user info when there's a JWT

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,9 +20,11 @@ const App = () => {
   useEffect(() => {
     if (jwt == null) {
       sessionStorage.removeItem('jwt');
-    } else {
-      sessionStorage.setItem('jwt', jwt);
+      setUser(null);
+      return;
     }
+
+    sessionStorage.setItem('jwt', jwt);
     getCurrentUser()
       .then(response => setUser(response.data))
       .catch(() => setUser(null));

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
-/* global sessionStorage */
+/* global localStorage */
 
+import isNil from 'lodash/isNil';
 import React, { useState, useEffect } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { getCurrentUser } from './lib/apiClient';
@@ -15,16 +16,16 @@ import ThanksPage from './containers/ThanksPage/ThanksPage';
 
 const App = () => {
   const [user, setUser] = useState(null);
-  const [jwt, setJwt] = useState(sessionStorage.jwt);
+  const [jwt, setJwt] = useState(localStorage.jwt);
 
   useEffect(() => {
-    if (jwt == null) {
-      sessionStorage.removeItem('jwt');
+    if (isNil(jwt)) {
+      localStorage.removeItem('jwt');
       setUser(null);
       return;
     }
 
-    sessionStorage.setItem('jwt', jwt);
+    localStorage.setItem('jwt', jwt);
     getCurrentUser()
       .then(response => setUser(response.data))
       .catch(() => setUser(null));

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -1,4 +1,4 @@
-/* global sessionStorage */
+/* global localStorage */
 /* eslint no-undef: "error" */
 
 import axios from 'axios';
@@ -32,7 +32,7 @@ const loginUser = (data) => {
 
 const getCurrentUser = () => apiClient.get('api/v1/auth', {
   headers: {
-    Authorization: sessionStorage.jwt,
+    Authorization: localStorage.jwt,
   },
 });
 
@@ -43,7 +43,7 @@ const getUsers = () => apiClient.get('api/v1/users')
 
 const getUser = userId => apiClient.get(`api/v1/users/${userId}`, {
   headers: {
-    Authorization: sessionStorage.jwt,
+    Authorization: localStorage.jwt,
   },
 });
 


### PR DESCRIPTION
### Describe The Problem Being Solved:

When I first wrote the login code in App.js, I thought I'd be clever and save a couple lines of code. Instead of failing early when the JWT is null, I let the API request go through and just set the user to `null` when it inevitably failed.

Unfortunately, React logs the 401 it gets in this case, which is confusing when you're trying to develop/debug things. It's also potentially annoying for a more sophisticated end user.

This change prevents us from trying to get the current user's data when there is no logged in user.