### PR TITLE
Fix broken names on signup form

### DIFF
--- a/frontend/src/components/SignUp/SignUp.js
+++ b/frontend/src/components/SignUp/SignUp.js
@@ -6,8 +6,8 @@ import { createUser } from '../../lib/apiClient';
 const SignUp = ({ history }) => {
   const [errorMsg, setError] = useState(null);
   const [user, setUser] = useState({
-    firstName: '',
-    lastName: '',
+    firstname: '',
+    lastname: '',
     email: '',
     password: '',
   });

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -14,8 +14,8 @@ const apiClient = axios.create({
 
 const createUser = data => apiClient.post('api/v1/auth', {
   user: {
-    first_name: data.firstName,
-    last_name: data.lastName,
+    first_name: data.firstname,
+    last_name: data.lastname,
     email: data.email,
     password: data.password,
   },


### PR DESCRIPTION
### Describe The Problem Being Solved:

When I abstracted out some of the form implementations, I inadvertently broke the signup form in such a way that first and last names weren't being recorded. This has to do with the way that React sometimes lowercases attribute names when they're passed through a layer of indirection.

This struck here (and was the cause of the already-fixed bug on the reset password page), causing the `firstName` and `lastName` keys in the `user` object to be lowercased. This resulted in a user object that looked like:
```
{
  firstName: '',
  firstname: 'Bryan',
  lastName: '',
  lastname: 'Vanderhoof',
  // etc.
}
```

The PR fixes this by setting up the initial object (and the apiClient object that uses the data) to expect the fields in lowercase.