### PR TITLE
Add react-helmet + title/OG tags to most pages

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14038,10 +14038,26 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.1.6.tgz",
       "integrity": "sha512-X1Y+0jR47ImDVr54Ab6V9eGk0Hnu7fVWGeHQSOXHf/C2pF9c6uy3gef8QUeuUiWlNb0i08InPSE5a/KJzNzw1Q=="
     },
+    "react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
     "react-fontawesome": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.5.0.tgz",
       "integrity": "sha1-h50bKqXEi7pVHpI3+EmTIXtWRcQ="
+    },
+    "react-helmet": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.1.tgz",
+      "integrity": "sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==",
+      "requires": {
+        "object-assign": "4.1.1",
+        "prop-types": "15.7.2",
+        "react-fast-compare": "2.0.4",
+        "react-side-effect": "1.2.0"
+      }
     },
     "react-is": {
       "version": "16.9.0",
@@ -14257,6 +14273,14 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
+      }
+    },
+    "react-side-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.2.0.tgz",
+      "integrity": "sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==",
+      "requires": {
+        "shallowequal": "1.1.0"
       }
     },
     "react-test-renderer": {
@@ -15643,6 +15667,11 @@
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
         }
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react-bootstrap-table2-paginator": "^2.0.3",
     "react-dom": "^16.8.4",
     "react-fontawesome": "~1.5.0",
+    "react-helmet": "^5.2.1",
     "react-router": "~5.0.1",
     "react-router-dom": "~5.0.1",
     "react-scripts": "~2.1.8",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@
 import isNil from 'lodash/isNil';
 import React, { useState, useEffect } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 import { getCurrentUser } from './lib/apiClient';
 import AdminPanel from './containers/AdminPanel/AdminPanel';
 import Homepage from './containers/Homepage/Homepage';
@@ -34,6 +35,13 @@ const App = () => {
 
   return (
     <div>
+      <Helmet titleTemplate="%s | Rescuing Leftover Cuisine" defaultTitle="Rescuing Leftover Cuisine">
+        <meta property="og:title" content="Rescuing Leftover Cuisine" />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content="https://rlc-prod.herokuapp.com/static/media/RLC_logo.4e05bcde.png" />
+        <meta property="og:image:alt" content="Rescuing Leftover Cuisine Logo" />
+      </Helmet>
+
       <Switch>
         <Route
           exact

--- a/frontend/src/containers/AdminPanel/AdminPanel.js
+++ b/frontend/src/containers/AdminPanel/AdminPanel.js
@@ -1,7 +1,9 @@
+import map from 'lodash/map';
 import React, { Component } from 'react';
 import {
   TabContent, TabPane, Nav, NavItem, NavLink, Button,
 } from 'reactstrap';
+import { Helmet } from 'react-helmet';
 import Header from '../../components/Header/Header';
 import Footer from '../../components/Footer/Footer';
 import Recipes from '../../components/AdminControls/Recipes';
@@ -45,7 +47,7 @@ class AdminPanel extends Component {
   }
 
   createFullName = (data) => {
-    const newData = data.map((obj) => {
+    const newData = map(data, (obj) => {
       const newObj = obj;
       newObj.full_name = `${obj.first_name} ${obj.last_name}`;
       return newObj;
@@ -69,6 +71,11 @@ class AdminPanel extends Component {
 
     return (
       <div className="admin-panel-container">
+        <Helmet>
+          <title>Admin</title>
+          <meta property="og:title" content="Admin | Rescuing Leftover Cuisine" />
+        </Helmet>
+
         <div className="admin-header">
           <Header showSearchBar user={user} setJwt={setJwt} />
         </div>

--- a/frontend/src/containers/LoginPage/LoginPage.js
+++ b/frontend/src/containers/LoginPage/LoginPage.js
@@ -1,10 +1,16 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import { AuthPage } from '../../components/AuthItems/AuthItems';
 import SignIn from '../../components/SignIn/SignIn';
 import SignUp from '../../components/SignUp/SignUp';
 
 const LoginPage = ({ setJwt }) => (
   <AuthPage>
+    <Helmet>
+      <title>Login</title>
+      <meta property="og:title" content="Login | Rescuing Leftover Cuisine" />
+    </Helmet>
+
     <SignUp />
     <div className="auth-page-divider" />
     <SignIn setJwt={setJwt} />

--- a/frontend/src/containers/ProfilePage/ProfilePage.js
+++ b/frontend/src/containers/ProfilePage/ProfilePage.js
@@ -3,6 +3,7 @@ import {
   TabContent, TabPane, Nav, NavItem, NavLink,
 } from 'reactstrap';
 import { withRouter } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 import map from 'lodash/map';
 import isNil from 'lodash/isNil';
 import Header from '../../components/Header/Header';
@@ -86,6 +87,14 @@ const ProfilePage = ({
   if (!isNil(user)) {
     return (
       <div className="profile-page container-fluid">
+        <Helmet>
+          <title>Profile</title>
+          <meta property="og:title" content="Profile | Rescuing Leftover Cuisine" />
+          <meta property="og:type" content="profile" />
+          <meta property="og:profile:first_name" content={user.first_name} />
+          <meta property="og:profile:last_name" content={user.last_name} />
+          <meta property="og:profile:username" content={user.email} />
+        </Helmet>
         <div className="row">
           <div className="profile-header">
             <Header showSearchBar user={user} setJwt={setJwt} />

--- a/frontend/src/containers/RecipePage/Recipe.js
+++ b/frontend/src/containers/RecipePage/Recipe.js
@@ -1,6 +1,7 @@
 import map from 'lodash/map';
 import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
+import { Helmet } from 'react-helmet';
 import Header from '../../components/Header/Header';
 import Footer from '../../components/Footer/Footer';
 import TagsBar from '../../components/TagsBar/TagsBar';
@@ -81,6 +82,13 @@ class Recipe extends Component {
     };
     return (
       <div className="recipe-overall-container">
+        <Helmet>
+          <title>{title}</title>
+          <meta property="og:title" content={`${title} | Rescuing Leftover Cuisine`} />
+          <meta property="og:image" content={photo} />
+          <meta property="og:image:alt" content={title} />
+        </Helmet>
+
         <div className="row">
           <div className="header">
             <Header user={user} setJwt={setJwt} />

--- a/frontend/src/containers/ResetPassword/ResetPasswordPage.js
+++ b/frontend/src/containers/ResetPassword/ResetPasswordPage.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import querystring from 'querystring';
 import { AuthPage } from '../../components/AuthItems/AuthItems';
 import NewPassword from '../../components/NewPassword/NewPassword';
@@ -9,6 +10,9 @@ const ResetPasswordPage = ({ location, setJwt }) => {
 
   return (
     <AuthPage>
+      <Helmet>
+        <title>Reset Password</title>
+      </Helmet>
       <NewPassword token={token} setJwt={setJwt} />
     </AuthPage>
   );

--- a/frontend/src/containers/ResetRequestPage/ResetRequestPage.js
+++ b/frontend/src/containers/ResetRequestPage/ResetRequestPage.js
@@ -1,9 +1,15 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import { AuthPage } from '../../components/AuthItems/AuthItems';
 import ResetRequest from '../../components/ResetRequest/ResetRequest';
 
 const ResetRequestPage = () => (
   <AuthPage>
+    <Helmet>
+      <title>Reset Password</title>
+      <meta property="og:title" content="Reset Password | Rescuing Leftover Cuisine" />
+    </Helmet>
+
     <ResetRequest />
   </AuthPage>
 );

--- a/frontend/src/containers/ThanksPage/ThanksPage.js
+++ b/frontend/src/containers/ThanksPage/ThanksPage.js
@@ -1,9 +1,13 @@
 import React from 'react';
+import { Helmet } from 'react-helmet';
 import { AuthPage } from '../../components/AuthItems/AuthItems';
 import ThankYouCard from '../../components/ThankYouCard/ThankYouCard';
 
 const ThanksPage = () => (
   <AuthPage>
+    <Helmet>
+      <title>Thanks!</title>
+    </Helmet>
     <ThankYouCard />
   </AuthPage>
 );


### PR DESCRIPTION
In order to enable sharing (and provide a better user experience), pages need functional titles and open graph data. In order to enable that, I added a library called react-helmet, which allows you to modify the data in the `head` tag on the fly.