### PR TITLE
Fix logout

### DIFF
--- a/db/migrate/20191001005214_add_expiration_time_to_jwt_blacklist.rb
+++ b/db/migrate/20191001005214_add_expiration_time_to_jwt_blacklist.rb
@@ -1,0 +1,5 @@
+class AddExpirationTimeToJwtBlacklist < ActiveRecord::Migration[5.2]
+  def change
+    add_column :jwt_blacklist, :exp, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_11_003854) do
+ActiveRecord::Schema.define(version: 2019_10_01_005214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "jwt_blacklist", force: :cascade do |t|
     t.string "jti", null: false
+    t.datetime "exp", null: false
     t.index ["jti"], name: "index_jwt_blacklist_on_jti"
   end
 

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -28,7 +28,7 @@ const loginUser = (data) => {
   });
 };
 
-const endSession = () => apiClient.delete('/api/v1/auth/logout', {
+const endSession = () => apiClient.delete('api/v1/auth/logout', {
   headers: {
     Authorization: localStorage.jwt,
   },


### PR DESCRIPTION
Logout currently causes a 500 error due to a missing column on the `jti_blacklist` table. This was caused by upgrading devise, and the upgraded version expects a certain column to be there.