### PR TITLE
Use env var substitution to default npm port value

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     }
   },
   "scripts": {
-    "start": "PORT=5000 react-scripts start",
+    "start": "PORT=${PORT:-5000} react-scripts start",
     "build": "react-scripts build",
     "coverage": "react-scripts test --coverage ; open coverage/lcov-report/index.html",
     "lint": "bash ./scripts/lint.sh",


### PR DESCRIPTION
An inline env var was added last sprint to package.json to ensure the frontend started on port 5000 in local environments. Unfortunately, the deployment process on Heroku also runs `npm start`, which picked up this port change and prevented the app from connecting to the correct port.

This changes that env var to default to 5000 in the absence of another value, but otherwise to respect the existing PORT setting.
