### PR TITLE
Update and organize readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ Any gotchas that aren’t intuitive.
 
 # Dev Setup
 
-## Local Environment
-
-### Language Versions
-
 We require specific versions of Node (8.11.4) and Ruby (2.5.3) in this project. Though the application runs in a Docker container with fixed versions, you may need to run commands in your local environment, like linting and testing described below. In order to get the correct versions installed, it is recommended to use a VM (version manager) like [asdf-vm](https://asdf-vm.com/#/).
 
-Loosely, you'll want to [install asdf](https://asdf-vm.com/#/core-manage-asdf-vm?id=install-asdf-vm), then run:
+
+## Local Environment Setup
+
+### ASDF
+
+In order to be able to develop code locally, you'll want to [install asdf](https://asdf-vm.com/#/core-manage-asdf-vm?id=install-asdf-vm), then run:
 
 ```
 asdf plugin-add ruby
@@ -22,6 +23,118 @@ asdf install ruby 2.5.3
 asdf plugin-add nodejs
 asdf install nodejs 8.11.4
 ```
+
+### Docker
+
+#### New to Docker?
+If you are completely new to Docker, please see the [Getting Started with Docker Guide](https://docs.docker.com/get-started/) on Docker's official website. Your first exposure to using containers can be confusing, so please don't hesitate to ask your team's Technical Lead for help.
+
+#### Install Docker
+Select the installation guide below for your laptop's operating system:
+- [**Mac OSX**](https://docs.docker.com/docker-for-mac/install/)
+- [**Linux**](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository)
+- [**Windows**](https://docs.docker.com/docker-for-windows/install/)
+
+#### Install Docker Compose
+##### Mac OSX & Windows
+For **Mac OSX** and **Windows** users, Docker Compose is already included with the Docker toolbox.
+
+##### Linux
+For linux users, you will have to install the docker compose binary from the [Docker Compoose release repository](https://github.com/docker/compose/releases). Please follow the instructions below to properly install docker compose:
+
+1. Run this command in your terminal to install the Docker Compose binary
+
+```
+sudo curl -L https://github.com/docker/compose/releases/download/1.22.0-rc2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+```
+
+2. Apply [executable permissions](https://ryanstutorials.net/linuxtutorial/permissions.php) to the binary
+
+```
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+3.) Run the following command to confirm that Docker Compose was properly installed:
+```
+docker-compose --version
+```
+You should expect the results to look similar to:
+```
+docker-compose version 1.22.0, build something
+```
+
+Useful commands for using Docker:
+#### Building rlc images
+Build the docker images by running the following command:
+```
+docker-compose build
+```
+This will build your `web` image and download the `db` image.
+
+#### Running rlc-web containers
+
+1. Run following command to start your containers:
+```
+docker-compose up
+```
+
+#### Stopping rlc-web containers
+You can try to stop the running containers from the running `docker-compose up` session by pressing CTRL-C.
+
+You can delete the containers (resetting the database) entirely by running `docker-compose down`.
+
+#### Updating dependencies
+
+Sometimes, someone else will add or update a dependency, whether that's a Ruby gem or an npm package. When that gets merged into staging, you'll need to download the update, as well. To do that, it's easiest to destroy your containers and rebuild the application:
+
+```
+docker-compose down
+docker-compose build
+```
+
+#### Resetting images/containers
+Sometimes issues will come up with your Docker instance than cannot be solved with a simple `docker-compose up/down`. In these cases, it is recommended to use the "nuclear option" and wipe out all running containers and images and then rebuild them:
+
+1. Stop all containers: `docker stop $(docker ps -aq)`
+    * If you receive the message `"docker stop" requires at least 1 argument.` it means that there are no running containers; it is safe to proceed.
+2. Remove all containers: `docker rm $(docker ps -aq)`
+    * If you receive the message `"docker rm" requires at least 1 argument.` it means that there are no built containers; it is safe to proceed.
+3. Remove all images: `docker rmi $(docker images -q)`
+    * If you receive the message `"docker rmi" requires at least 1 argument.` it means that there are no downloaded images; it is safe to proceed.
+4. Download images and rebuild containers: `docker-compose up`
+
+
+### Editorconfig
+
+Please install one of the following code editors (unless you're already using one of them): VSCode, Atom, Sublime Text
+
+We have a `.editorconfig` file which specifies some default text editor settings that should help with code styling (e.g. cleaning up whitespace). This requires a plugin to work, so follow the link below to the install instructions for you specific editor:
+
+* [VSCode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
+* [Atom](https://atom.io/packages/editorconfig)
+* [Sublime Text](https://github.com/sindresorhus/editorconfig-sublime)
+
+
+The local setup ends here. Please continue to read about more tools and useful commands we're using, below:
+_________________________________________________________________________________________________________
+
+## How we spin our app locally
+TBD 
+
+
+# Deployment
+
+The site is presently deployed to Heroku as two separate apps: the API and the frontend.
+
+When the staging branch is updated, it automatically deploys to the staging app, which you can find at https://rlc-stg.herokuapp.com/
+
+When the master branch is updated, it automatically deploys to the production app, which you can find at https://rlc-prod.herokuapp.com/
+
+We typically use the staging app to do QA at the end of each sprint, before merging the completed work into master. We demo from the production app.
+
+
+# Other useful tools and commands
 
 ### Lodash
 
@@ -55,14 +168,6 @@ npm run lint -- --fix
 
 Note: You will have to run `npm install` before-hand (again, also from within the `frontend/` directory) in order for this to work.
 
-### Editorconfig
-
-We have a `.editorconfig` file which specifies some default text editor settings that should help with code styling (e.g. cleaning up whitespace). This requires a plugin to work, so follow the link below to the install instructions for you specific editor:
-
-* [VSCode](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
-* [Atom](https://atom.io/packages/editorconfig)
-* [Sublime Text](https://github.com/sindresorhus/editorconfig-sublime)
-
 ### Environment Variables
 
 We use [environment variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa) to control some configuration aspects of the application. When deployed to Heroku, these values are set using the "config var" apparatus, but in our local development environment, we don't have access to those. In most cases, we rely on defaults in development, but there are a few cases where environment variables are necessary.
@@ -77,102 +182,14 @@ cp .env.example .env
 
 This will provide the minimum you need to run the site on your local computer. If you need to work on signup/confirmation/forgot password workflows, you'll also need to set the sendgrid configuration to enable sending emails. Talk to a tech lead if you need those credentials.
 
-## Docker
-
-### New to Docker?
-If you are completely new to Docker, please see the [Getting Started with Docker Guide](https://docs.docker.com/get-started/) on Docker's official website. Your first exposure to using containers can be confusing, so please don't hesitate to ask your team's Technical Lead for help.
-
-### Install Docker
-Select the installation guide below for your laptop's operating system:
-- [**Mac OSX**](https://docs.docker.com/docker-for-mac/install/)
-- [**Linux**](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#set-up-the-repository)
-- [**Windows**](https://docs.docker.com/docker-for-windows/install/)
-
-### Install Docker Compose
-#### Mac OSX & Windows
-For **Mac OSX** and **Windows** users, Docker Compose is already included with the Docker toolbox.
-
-#### Linux
-For linux users, you will have to install the docker compose binary from the [Docker Compoose release repository](https://github.com/docker/compose/releases). Please follow the instructions below to properly install docker compose:
-
-1. Run this command in your terminal to install the Docker Compose binary
-
-```
-sudo curl -L https://github.com/docker/compose/releases/download/1.22.0-rc2/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-```
-
-2. Apply [executable permissions](https://ryanstutorials.net/linuxtutorial/permissions.php) to the binary
-
-```
-sudo chmod +x /usr/local/bin/docker-compose
-```
-
-3.) Run the following command to confirm that Docker Compose was properly installed:
-```
-docker-compose --version
-```
-You should expect the results to look similar to:
-```
-docker-compose version 1.22.0, build something
-```
-
-### Building rlc images
-Build the docker images by running the following command:
-```
-docker-compose build
-```
-This will build your `web` image and download the `db` image.
-
-### Running rlc-web containers
-
-1. Run following command to start your containers:
-```
-docker-compose up
-```
-
-### Stopping rlc-web containers
-You can try to stop the running containers from the running `docker-compose up` session by pressing CTRL-C.
-
-You can delete the containers (resetting the database) entirely by running `docker-compose down`.
-
-### Updating dependencies
-
-Sometimes, someone else will add or update a dependency, whether that's a Ruby gem or an npm package. When that gets merged into staging, you'll need to download the update, as well. To do that, it's easiest to destroy your containers and rebuild the application:
-
-```
-docker-compose down
-docker-compose build
-```
-
-### Resetting images/containers
-Sometimes issues will come up with your Docker instance than cannot be solved with a simple `docker-compose up/down`. In these cases, it is recommended to use the "nuclear option" and wipe out all running containers and images and then rebuild them:
-
-1. Stop all containers: `docker stop $(docker ps -aq)`
-    * If you receive the message `"docker stop" requires at least 1 argument.` it means that there are no running containers; it is safe to proceed.
-2. Remove all containers: `docker rm $(docker ps -aq)`
-    * If you receive the message `"docker rm" requires at least 1 argument.` it means that there are no built containers; it is safe to proceed.
-3. Remove all images: `docker rmi $(docker images -q)`
-    * If you receive the message `"docker rmi" requires at least 1 argument.` it means that there are no downloaded images; it is safe to proceed.
-4. Download images and rebuild containers: `docker-compose up`
-
-# Deployment
-
-The site is presently deployed to Heroku as two separate apps: the API and the frontend.
-
-When the staging branch is updated, it automatically deploys to the staging app, which you can find at https://rlc-stg.herokuapp.com/
-
-When the master branch is updated, it automatically deploys to the production app, which you can find at https://rlc-prod.herokuapp.com/
-
-We typically use the staging app to do QA at the end of each sprint, before merging the completed work into master. We demo from the production app.
-
-# Dependencies
+### Dependencies
 
 For icons throughout the site, we use [icons8](https://icons8.com/).
 
 We use React on the frontend, employing Bootstrap and Reactstrap for styling.
 
 We use Ruby on Rails in API mode on the backend, with Devise for authentication.
+
 
 # Project directory structure
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,21 @@ Ask questions and try to understand your requirement.
 
 3. On the new feature branch, start developing your solution. Try to commit often to be able to follow your progress.
 
-4. Feel free to use rails console and http://localhost:3000 to visually test your changes.
+4. Feel free to run `rails console` and http://localhost:5000 to visually test your changes.
 
 5. Push you branch up: 'git push origin *branch_name*' or 'git push origin HEAD'
 
-6. In Github, make a Pull Request (PR) and follow up on the comments you receive, in order to make code changes.
+6. In Github, make a Pull Request (PR), and make sure a tech lead or mentor is marked as a reviewer or assignee
+
+  1. Follow-up on the reviewer's feedback, and implement any requested code changes in your local branch
+
+  2. Push your local changes up to Github, making sure your local branch is up-to-date with the latest version of the `staging` branch
+
+  3. Re-request a review from a tech lead or mentor
+
+  4. Repeat steps 6a through 6c until your PR is approved
+
+  5. Merge your branch into Github
 
 7. Mark your ticket as Done in Zenhub.
 Congrats on getting it done!

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ We require specific versions of Node (8.11.4) and Ruby (2.5.3) in this project. 
 
 
 ## Local Environment Setup
+If you've already used a package manager like rvm or rbenv for ruby or npm for node on your machine, make sure you have ruby 2.5.3 and node 8.11.4 installed for this project. Otherwise, please follow the instructions for installing asdf below:
 
 ### ASDF
 
-In order to be able to develop code locally, you'll want to [install asdf](https://asdf-vm.com/#/core-manage-asdf-vm?id=install-asdf-vm), then run:
+You'll need to [install asdf](https://asdf-vm.com/#/core-manage-asdf-vm?id=install-asdf-vm), then run:
 
 ```
 asdf plugin-add ruby
@@ -104,6 +105,20 @@ Sometimes issues will come up with your Docker instance than cannot be solved wi
     * If you receive the message `"docker rmi" requires at least 1 argument.` it means that there are no downloaded images; it is safe to proceed.
 4. Download images and rebuild containers: `docker-compose up`
 
+### Environment Variables
+
+We use [environment variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa) to control some configuration aspects of the application. When deployed to Heroku, these values are set using the "config var" apparatus, but in our local development environment, we don't have access to those. In most cases, we rely on defaults in development, but there are a few cases where environment variables are necessary.
+
+We use the `dotenv` [Ruby gem](https://github.com/bkeepers/dotenv) and [npm package](https://www.npmjs.com/package/dotenv). These packages allow us to define environment variables in our local environment using a file called `.env`. For example, the backend requires a variety of secret keys to generate JSON Web Tokens, and we define those in our `.env` file. When the application starts up, it reads those variables from that file.
+
+Since the `.env` file can contain sensitive information, we don't commit it (it's [gitignored](https://git-scm.com/docs/gitignore)), so you need to create one on your local computer. To set yours up, copy the existing `.env.example` file to the `.env` file:
+
+```
+cp .env.example .env
+```
+
+This will provide the minimum you need to run the site on your local computer. If you need to work on signup/confirmation/forgot password workflows, you'll also need to set the sendgrid configuration to enable sending emails. Talk to a tech lead if you need those credentials.
+
 
 ### Editorconfig
 
@@ -116,11 +131,46 @@ We have a `.editorconfig` file which specifies some default text editor settings
 * [Sublime Text](https://github.com/sindresorhus/editorconfig-sublime)
 
 
-The local setup ends here. Please continue to read about more tools and useful commands we're using, below:
+The local setup ends here. Please continue to read about Steps to Develop Locally, about more tools and useful commands we're using, below:
 _________________________________________________________________________________________________________
 
-## How we spin our app locally
-TBD 
+## Steps to spin the app locally
+
+1. Clone this repository locally unless you've already done so:
+git clone git@github.com:the-difference-engine/rescue-leftover-cuisine2.git
+
+2. in your terminal, navigate locally to the rescue-leftover-cuisine2 folder
+
+3. run 'bundle install'
+
+4. run 'rails server' or 'rails s' to start the server
+
+5. Change your current working directory to the `frontend` folder (`cd frontend` if you're currently in the project root)
+
+6. Run `npm install`
+
+7. Run `PORT=5000 npm start`
+
+8. Navigate to 'http://localhost:5000' in your browser
+
+
+## Steps to develop locally
+
+1. Ask your product manager to assign you on a Zenhub ticket.
+Ask questions and try to understand your requirement.
+
+2. Make a new git branch off of the staging branch
+
+3. On the new feature branch, start developing your solution. Try to commit often to be able to follow your progress.
+
+4. Feel free to use rails console and http://localhost:3000 to visually test your changes.
+
+5. Push you branch up: 'git push origin *branch_name*' or 'git push origin HEAD'
+
+6. In Github, make a Pull Request (PR) and follow up on the comments you receive, in order to make code changes.
+
+7. Mark your ticket as Done in Zenhub.
+Congrats on getting it done!
 
 
 # Deployment
@@ -167,20 +217,6 @@ npm run lint -- --fix
 ```
 
 Note: You will have to run `npm install` before-hand (again, also from within the `frontend/` directory) in order for this to work.
-
-### Environment Variables
-
-We use [environment variables](https://medium.com/chingu/an-introduction-to-environment-variables-and-how-to-use-them-f602f66d15fa) to control some configuration aspects of the application. When deployed to Heroku, these values are set using the "config var" apparatus, but in our local development environment, we don't have access to those. In most cases, we rely on defaults in development, but there are a few cases where environment variables are necessary.
-
-We use the `dotenv` [Ruby gem](https://github.com/bkeepers/dotenv) and [npm package](https://www.npmjs.com/package/dotenv). These packages allow us to define environment variables in our local environment using a file called `.env`. For example, the backend requires a variety of secret keys to generate JSON Web Tokens, and we define those in our `.env` file. When the application starts up, it reads those variables from that file.
-
-Since the `.env` file can contain sensitive information, we don't commit it (it's [gitignored](https://git-scm.com/docs/gitignore)), so you need to create one on your local computer. To set yours up, copy the existing `.env.example` file to the `.env` file:
-
-```
-cp .env.example .env
-```
-
-This will provide the minimum you need to run the site on your local computer. If you need to work on signup/confirmation/forgot password workflows, you'll also need to set the sendgrid configuration to enable sending emails. Talk to a tech lead if you need those credentials.
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -65,45 +65,7 @@ You should expect the results to look similar to:
 docker-compose version 1.22.0, build something
 ```
 
-Useful commands for using Docker:
-#### Building rlc images
-Build the docker images by running the following command:
-```
-docker-compose build
-```
-This will build your `web` image and download the `db` image.
-
-#### Running rlc-web containers
-
-1. Run following command to start your containers:
-```
-docker-compose up
-```
-
-#### Stopping rlc-web containers
-You can try to stop the running containers from the running `docker-compose up` session by pressing CTRL-C.
-
-You can delete the containers (resetting the database) entirely by running `docker-compose down`.
-
-#### Updating dependencies
-
-Sometimes, someone else will add or update a dependency, whether that's a Ruby gem or an npm package. When that gets merged into staging, you'll need to download the update, as well. To do that, it's easiest to destroy your containers and rebuild the application:
-
-```
-docker-compose down
-docker-compose build
-```
-
-#### Resetting images/containers
-Sometimes issues will come up with your Docker instance than cannot be solved with a simple `docker-compose up/down`. In these cases, it is recommended to use the "nuclear option" and wipe out all running containers and images and then rebuild them:
-
-1. Stop all containers: `docker stop $(docker ps -aq)`
-    * If you receive the message `"docker stop" requires at least 1 argument.` it means that there are no running containers; it is safe to proceed.
-2. Remove all containers: `docker rm $(docker ps -aq)`
-    * If you receive the message `"docker rm" requires at least 1 argument.` it means that there are no built containers; it is safe to proceed.
-3. Remove all images: `docker rmi $(docker images -q)`
-    * If you receive the message `"docker rmi" requires at least 1 argument.` it means that there are no downloaded images; it is safe to proceed.
-4. Download images and rebuild containers: `docker-compose up`
+After you're done setting up your local environment, you can read more about Docker and find some useful commands below, under "More about Docker"
 
 ### Environment Variables
 
@@ -225,6 +187,48 @@ For icons throughout the site, we use [icons8](https://icons8.com/).
 We use React on the frontend, employing Bootstrap and Reactstrap for styling.
 
 We use Ruby on Rails in API mode on the backend, with Devise for authentication.
+
+# More about Docker
+
+Useful commands for using Docker:
+## Building rlc images
+Build the docker images by running the following command:
+```
+docker-compose build
+```
+This will build your `web` image and download the `db` image.
+
+## Running rlc-web containers
+
+1. Run following command to start your containers:
+```
+docker-compose up
+```
+
+## Stopping rlc-web containers
+You can try to stop the running containers from the running `docker-compose up` session by pressing CTRL-C.
+
+You can delete the containers (resetting the database) entirely by running `docker-compose down`.
+
+#### Updating dependencies
+
+Sometimes, someone else will add or update a dependency, whether that's a Ruby gem or an npm package. When that gets merged into staging, you'll need to download the update, as well. To do that, it's easiest to destroy your containers and rebuild the application:
+
+```
+docker-compose down
+docker-compose build
+```
+
+## Resetting images/containers
+Sometimes issues will come up with your Docker instance than cannot be solved with a simple `docker-compose up/down`. In these cases, it is recommended to use the "nuclear option" and wipe out all running containers and images and then rebuild them:
+
+1. Stop all containers: `docker stop $(docker ps -aq)`
+    * If you receive the message `"docker stop" requires at least 1 argument.` it means that there are no running containers; it is safe to proceed.
+2. Remove all containers: `docker rm $(docker ps -aq)`
+    * If you receive the message `"docker rm" requires at least 1 argument.` it means that there are no built containers; it is safe to proceed.
+3. Remove all images: `docker rmi $(docker images -q)`
+    * If you receive the message `"docker rmi" requires at least 1 argument.` it means that there are no downloaded images; it is safe to proceed.
+4. Download images and rebuild containers: `docker-compose up`
 
 
 # Project directory structure


### PR DESCRIPTION
### Ticket Number:
no ticket number

### Describe The Problem Being Solved:
This PR is trying to resolve the problem that we have when we're onboarding new apprentices and the local setup takes too long.
I've tried to separate the instructions that are strictly meant for local setup, from the ones that invite apprentices to learn and understand what some tools are useful for. I felt that as soon as the apprentice has their local environment ready to start development, they could pick a task sooner and then, in their own time, study further about some topics (for example, what asdf does).

I also added steps that we use to spin up the server and steps we roughly use in the development process. I need some help figuring out the steps that involve the frontend.

Please let me know what you think. I'm happy to close this PR if you think it's a bad idea, or make the changes that you think are needed. Thank you!

### Checklist For Submitter

* [ x ] I have documented all new functionality
* n/a  I have screenshotted new UI changes and attached them to this PR
