### PR TITLE
Feature/390/link to admin

### DIFF
--- a/frontend/src/components/HeaderDropdown/HeaderDropdown.js
+++ b/frontend/src/components/HeaderDropdown/HeaderDropdown.js
@@ -46,7 +46,7 @@ const HeaderDropdown = ({ history, user, setJwt }) => {
         <Link className="header-dropdown-item" to="/profile#settings">
           <DropdownItem className="header-dropdown-item">Settings</DropdownItem>
         </Link>
-        {user.is_admin === true ? showAdminLink() : null}
+        {user.is_admin ? showAdminLink() : null}
         <DropdownItem divider />
         <DropdownItem onClick={logout} className="header-dropdown-item">Log Out</DropdownItem>
       </DropdownMenu>

--- a/frontend/src/components/HeaderDropdown/HeaderDropdown.js
+++ b/frontend/src/components/HeaderDropdown/HeaderDropdown.js
@@ -18,6 +18,12 @@ const HeaderDropdown = ({ history, user, setJwt }) => {
     history.push('/');
   };
 
+  const showAdminLink = () => (
+    <Link className="header-dropdown-item" to="/admin">
+      <DropdownItem className="header-dropdown-item">Administration</DropdownItem>
+    </Link>
+  );
+
   return (
     <Dropdown isOpen={dropdownOpen} toggle={toggleDropdown}>
       <DropdownToggle tag="button" className="header-dropdown-toggle">
@@ -40,6 +46,7 @@ const HeaderDropdown = ({ history, user, setJwt }) => {
         <Link className="header-dropdown-item" to="/profile#settings">
           <DropdownItem className="header-dropdown-item">Settings</DropdownItem>
         </Link>
+        {user.is_admin === true ? showAdminLink() : null}
         <DropdownItem divider />
         <DropdownItem onClick={logout} className="header-dropdown-item">Log Out</DropdownItem>
       </DropdownMenu>

--- a/frontend/src/containers/ProfilePage/ProfilePage.js
+++ b/frontend/src/containers/ProfilePage/ProfilePage.js
@@ -76,6 +76,14 @@ const ProfilePage = ({
     },
   ];
 
+  const showAdminLink = () => (
+    <NavItem>
+      <NavLink onClick={() => history.push('/admin')}>
+        Administration
+      </NavLink>
+    </NavItem>
+  );
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
@@ -89,6 +97,7 @@ const ProfilePage = ({
   }
 
   if (!isNil(user)) {
+    console.log(user);
     return (
       <div className="profile-page container-fluid">
         <Helmet>
@@ -121,6 +130,7 @@ const ProfilePage = ({
                     Settings
                   </NavLink>
                 </NavItem>
+                {user.is_admin === true ? showAdminLink() : null}
               </Nav>
             </div>
             <div className="col-md-9 right-pane">

--- a/frontend/src/containers/ProfilePage/ProfilePage.js
+++ b/frontend/src/containers/ProfilePage/ProfilePage.js
@@ -127,7 +127,7 @@ const ProfilePage = ({
                     Settings
                   </NavLink>
                 </NavItem>
-                {user.is_admin === true ? showAdminLink() : null}
+                {user.is_admin ? showAdminLink() : null}
               </Nav>
             </div>
             <div className="col-md-9 right-pane">

--- a/frontend/src/containers/ProfilePage/ProfilePage.js
+++ b/frontend/src/containers/ProfilePage/ProfilePage.js
@@ -97,7 +97,6 @@ const ProfilePage = ({
   }
 
   if (!isNil(user)) {
-    console.log(user);
     return (
       <div className="profile-page container-fluid">
         <Helmet>


### PR DESCRIPTION
### Ticket Number: [390](https://app.zenhub.com/workspaces/rescue-leftover-cuisine2-5b4407b97c849143424ea288/issues/the-difference-engine/rescue-leftover-cuisine2/390)

### Describe The Problem Being Solved:
Added links to allow admins to access the admin panel. 


### Checklist For Submitter

* [ x] I have documented all new functionality
* [ x] I have screenshotted new UI changes and attached them to this PR
![Screen Shot 2019-11-18 at 8 07 48 PM](https://user-images.githubusercontent.com/38137359/69110179-7f1c4d00-0a3f-11ea-8216-732cd6c20732.png)
![Screen Shot 2019-11-18 at 8 08 30 PM](https://user-images.githubusercontent.com/38137359/69110180-7fb4e380-0a3f-11ea-99fa-a22f4068d3ea.png)