### PR TITLE
Prevent loading components that depend on users until we load the user

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,22 +16,27 @@ import ResetRequestPage from './containers/ResetRequestPage/ResetRequestPage';
 import ThanksPage from './containers/ThanksPage/ThanksPage';
 import ConfirmUser from './components/ConfirmUser/ConfirmUser';
 import Page404 from './containers/Page404/Page404';
+import Loading from './components/Loading/Loading';
 
 const App = () => {
   const [user, setUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [jwt, setJwt] = useState(localStorage.jwt);
 
   useEffect(() => {
+    setIsLoading(true);
     if (isNil(jwt)) {
       localStorage.removeItem('jwt');
       setUser(null);
+      setIsLoading(false);
       return;
     }
 
     localStorage.setItem('jwt', jwt);
     getCurrentUser()
       .then(response => setUser(response.data))
-      .catch(() => setUser(null));
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false));
   }, [jwt]);
 
   return (
@@ -52,11 +57,13 @@ const App = () => {
         <Route path="/login" render={props => <LoginPage {...props} setJwt={setJwt} />} />
         <Route
           path="/admin"
-          render={props => <AdminPanel {...props} user={user} setJwt={setJwt} />}
+          render={props => (isLoading ? <Loading />
+            : <AdminPanel {...props} user={user} setJwt={setJwt} />)}
         />
         <Route
           path="/recipe/new"
-          render={props => <CreateRecipe {...props} user={user} setJwt={setJwt} />}
+          render={props => (isLoading ? <Loading />
+            : <CreateRecipe {...props} user={user} setJwt={setJwt} />)}
         />
         <Route
           exact
@@ -65,11 +72,13 @@ const App = () => {
         />
         <Route
           path="/recipe/:id/edit"
-          render={props => <CreateRecipe {...props} user={user} setJwt={setJwt} />}
+          render={props => (isLoading ? <Loading />
+            : <CreateRecipe {...props} user={user} setJwt={setJwt} />)}
         />
         <Route
           path="/profile"
-          render={props => <ProfilePage {...props} user={user} setUser={setUser} setJwt={setJwt} />}
+          render={props => (isLoading ? <Loading />
+            : <ProfilePage {...props} user={user} setUser={setUser} setJwt={setJwt} />)}
         />
         <Route
           path="/resetpassword"

--- a/frontend/src/components/Loading/Loading.js
+++ b/frontend/src/components/Loading/Loading.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import './Loading.scss';
+
+const Loading = () => (
+  <div className="text-center" id="loading-wrapper">
+    <h1>Loading...</h1>
+  </div>
+);
+
+export default Loading;

--- a/frontend/src/components/Loading/Loading.scss
+++ b/frontend/src/components/Loading/Loading.scss
@@ -1,0 +1,3 @@
+#loading-wrapper {
+  margin-top: 50px;
+}

--- a/frontend/src/containers/AdminPanel/AdminPanel.js
+++ b/frontend/src/containers/AdminPanel/AdminPanel.js
@@ -1,5 +1,5 @@
 import map from 'lodash/map';
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   TabContent, TabPane, Nav, NavItem, NavLink, Button,
 } from 'reactstrap';
@@ -13,51 +13,16 @@ import Recipes from '../../components/AdminControls/Recipes';
 import Users from '../../components/AdminControls/Users';
 import './AdminPanel.scss';
 
-class AdminPanel extends Component {
-  constructor(props) {
-    super(props);
+const AdminPanel = ({ user, setJwt }) => {
+  if (isNil(user)) return (<Redirect to="/login" />);
 
-    this.state = {
-      activeTab: 'recipes',
-      recipes: [],
-      users: [],
-      render: false,
-    };
+  if (!user.is_admin) return (<Redirect to="/" />);
 
-    this.toggle = this.toggle.bind(this);
-  }
+  const [activeTab, setActiveTab] = useState('recipes');
+  const [recipes, setRecipes] = useState([]);
+  const [users, setUsers] = useState([]);
 
-  componentDidMount() {
-    getRecipes().then((data) => {
-      this.setState({
-        recipes: data,
-      });
-    });
-
-    getUsers().then((data) => {
-      this.setState({
-        users: this.createFullName(data),
-      });
-    });
-
-    const { user } = this.props;
-
-    if (isNil(user)) {
-      setTimeout(() => {
-        this.setState({ render: true });
-      }, 2000);
-    } else this.setState({ render: true });
-  }
-
-  refreshUsers = () => {
-    getUsers().then((data) => {
-      this.setState({
-        users: this.createFullName(data),
-      });
-    });
-  }
-
-  createFullName = (data) => {
+  const createFullName = (data) => {
     const newData = map(data, (obj) => {
       const newObj = obj;
       newObj.full_name = `${obj.first_name} ${obj.last_name}`;
@@ -66,78 +31,60 @@ class AdminPanel extends Component {
     return newData;
   };
 
-  toggle(tab) {
-    const { activeTab } = this.state;
+  const refreshUsers = () => getUsers().then(data => setUsers(createFullName(data)));
 
-    if (activeTab !== tab) {
-      this.setState({
-        activeTab: tab,
-      });
-    }
-  }
+  useEffect(() => {
+    getRecipes().then(data => setRecipes(data));
+    refreshUsers();
+  }, []);
 
-  render() {
-    const { user, setJwt } = this.props;
-    const {
-      activeTab, recipes, users, render,
-    } = this.state;
-    if (render) {
-      if (isNil(user)) return (<Redirect to="/login" />);
-
-      if (!user.is_admin) return (<Redirect to="/" />);
-
-      if (!isNil(user)) {
-        return (
-          <div className="admin-panel-container">
-            <Helmet>
-              <title>Admin</title>
-              <meta property="og:title" content="Admin | Rescuing Leftover Cuisine" />
-            </Helmet>
-            <div className="admin-header">
-              <Header showSearchBar user={user} setJwt={setJwt} />
-            </div>
-            <Nav tabs>
-              <NavItem className={activeTab === 'recipes' ? 'nav-tab-line' : ''}>
-                <NavLink
-                  className={activeTab === 'recipes' ? 'recipes' : ''}
-                  onClick={() => {
-                    this.toggle('recipes');
-                  }}
-                >
-                  All Recipes
-                </NavLink>
-              </NavItem>
-              <NavItem className={activeTab === 'users' ? 'nav-tab-line' : ''}>
-                <NavLink
-                  className={activeTab === 'users' ? 'users' : ''}
-                  onClick={() => {
-                    this.toggle('users');
-                  }}
-                >
-                  All Members
-                </NavLink>
-              </NavItem>
-              {activeTab === 'recipes' && (
-                <Button className="admin-add-button" size="lg">
-                  Add Recipe
-                </Button>
-              )}
-            </Nav>
-            <TabContent id="bootstrap-overrides-pagination" activeTab={activeTab}>
-              <TabPane tabId="recipes" className="table">
-                <Recipes recipes={recipes} />
-              </TabPane>
-              <TabPane tabId="users" className="table">
-                <Users users={users} refreshUsers={this.refreshUsers} />
-              </TabPane>
-            </TabContent>
-            <Footer />
-          </div>
-        );
-      }
-    }
-    return null;
-  }
-}
+  return (
+    <div className="admin-panel-container">
+      <Helmet>
+        <title>Admin</title>
+        <meta property="og:title" content="Admin | Rescuing Leftover Cuisine" />
+      </Helmet>
+      <div className="admin-header">
+        <Header showSearchBar user={user} setJwt={setJwt} />
+      </div>
+      <Nav tabs>
+        <NavItem className={activeTab === 'recipes' ? 'nav-tab-line' : ''}>
+          <NavLink
+            className={activeTab === 'recipes' ? 'recipes' : ''}
+            onClick={() => {
+              setActiveTab('recipes');
+            }}
+          >
+            All Recipes
+          </NavLink>
+        </NavItem>
+        <NavItem className={activeTab === 'users' ? 'nav-tab-line' : ''}>
+          <NavLink
+            className={activeTab === 'users' ? 'users' : ''}
+            onClick={() => {
+              setActiveTab('users');
+            }}
+          >
+            All Members
+          </NavLink>
+        </NavItem>
+        {activeTab === 'recipes' && (
+          <Button className="admin-add-button" size="lg">
+            Add Recipe
+          </Button>
+        )}
+      </Nav>
+      <TabContent id="bootstrap-overrides-pagination" activeTab={activeTab}>
+        <TabPane tabId="recipes" className="table">
+          <Recipes recipes={recipes} />
+        </TabPane>
+        <TabPane tabId="users" className="table">
+          <Users users={users} refreshUsers={refreshUsers} />
+        </TabPane>
+      </TabContent>
+      <Footer />
+    </div>
+  );
+};
 
 export default AdminPanel;

--- a/frontend/src/containers/ProfilePage/ProfilePage.js
+++ b/frontend/src/containers/ProfilePage/ProfilePage.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
   TabContent, TabPane, Nav, NavItem, NavLink,
 } from 'reactstrap';
-import { withRouter } from 'react-router-dom';
+import { Redirect, withRouter } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
 import map from 'lodash/map';
 import isNil from 'lodash/isNil';
@@ -17,6 +17,8 @@ import './ProfilePage.scss';
 const ProfilePage = ({
   user, setUser, setJwt, history, location,
 }) => {
+  if (isNil(user)) return (<Redirect to="/login" />);
+
   const [recipes, setRecipes] = useState([]);
 
   const showAdminLink = () => (
@@ -30,7 +32,7 @@ const ProfilePage = ({
   useEffect(() => {
     window.scrollTo(0, 0);
     getUserRecipes(user.id).then(data => setRecipes(data));
-  }, []);
+  }, [user]);
 
   let activeTab = '';
 
@@ -40,80 +42,62 @@ const ProfilePage = ({
     activeTab = 'recipes';
   }
 
-  if (!isNil(user)) {
-    return (
-      <div className="profile-page container-fluid">
-        <Helmet>
-          <title>Profile</title>
-          <meta property="og:title" content="Profile | Rescuing Leftover Cuisine" />
-          <meta property="og:type" content="profile" />
-          <meta property="og:profile:first_name" content={user.first_name} />
-          <meta property="og:profile:last_name" content={user.last_name} />
-          <meta property="og:profile:username" content={user.email} />
-        </Helmet>
-        <div className="row">
-          <div className="profile-header">
-            <Header showSearchBar user={user} setJwt={setJwt} />
-          </div>
-        </div>
-        <div>
-          <UserInfo user={user} setUser={setUser} />
-          <div className="row user-panel">
-            <div className="col-md-2 user-nav-bar">
-              <Nav tabs>
-                <NavItem className={activeTab === 'recipes' ? 'user-nav-tab-active' : ''}>
-                  <NavLink
-                    onClick={() => history.push('/profile#recipes')}
-                  >
-                    My Recipes
-                  </NavLink>
-                </NavItem>
-                <NavItem className={activeTab === 'settings' ? 'user-nav-tab-active' : ''}>
-                  <NavLink onClick={() => history.push('/profile#settings')}>
-                    Settings
-                  </NavLink>
-                </NavItem>
-                {user.is_admin ? showAdminLink() : null}
-              </Nav>
-            </div>
-            <div className="col-md-9 right-pane">
-              <TabContent activeTab={activeTab}>
-                <TabPane tabId="recipes" id="recipes">
-                  <div id="cards-wrapper">
-                    {map(recipes, recipe => (
-                      <RecipeCard
-                        {...recipe}
-                        key={recipe.id}
-                      />
-                    ))}
-                  </div>
-                </TabPane>
-                <TabPane tabId="settings" id="settings">
-                  <SettingsTab />
-                </TabPane>
-              </TabContent>
-            </div>
-          </div>
-        </div>
-        <div className="row">
-          <Footer />
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="profile-page container-fluid">
+      <Helmet>
+        <title>Profile</title>
+        <meta property="og:title" content="Profile | Rescuing Leftover Cuisine" />
+        <meta property="og:type" content="profile" />
+        <meta property="og:profile:first_name" content={user.first_name} />
+        <meta property="og:profile:last_name" content={user.last_name} />
+        <meta property="og:profile:username" content={user.email} />
+      </Helmet>
       <div className="row">
         <div className="profile-header">
           <Header showSearchBar user={user} setJwt={setJwt} />
         </div>
       </div>
       <div>
-        <h1>Login to access this page.</h1>
-        <div className="row">
-          <Footer />
+        <UserInfo user={user} setUser={setUser} />
+        <div className="row user-panel">
+          <div className="col-md-2 user-nav-bar">
+            <Nav tabs>
+              <NavItem className={activeTab === 'recipes' ? 'user-nav-tab-active' : ''}>
+                <NavLink
+                  onClick={() => history.push('/profile#recipes')}
+                >
+                  My Recipes
+                </NavLink>
+              </NavItem>
+              <NavItem className={activeTab === 'settings' ? 'user-nav-tab-active' : ''}>
+                <NavLink onClick={() => history.push('/profile#settings')}>
+                  Settings
+                </NavLink>
+              </NavItem>
+              {user.is_admin ? showAdminLink() : null}
+            </Nav>
+          </div>
+          <div className="col-md-9 right-pane">
+            <TabContent activeTab={activeTab}>
+              <TabPane tabId="recipes" id="recipes">
+                <div id="cards-wrapper">
+                  {map(recipes, recipe => (
+                    <RecipeCard
+                      {...recipe}
+                      key={recipe.id}
+                    />
+                  ))}
+                </div>
+              </TabPane>
+              <TabPane tabId="settings" id="settings">
+                <SettingsTab />
+              </TabPane>
+            </TabContent>
+          </div>
         </div>
+      </div>
+      <div className="row">
+        <Footer />
       </div>
     </div>
   );


### PR DESCRIPTION
### Ticket Number:

Closes #392 
Closes #388

### Describe The Problem Being Solved:

When pages that require users load, especially the admin and profile pages, they weren't correctly handling a null user. We had some delays and such, but they were very kludgy.

Additionally, some pages were open to all viewers, when they should only be available to users.

This fixes those problems by pausing while we load the user on initial page load. This shouldn't affect normal navigation; it'll only fire if the page first loads on a page that requires login.

To fix a bug I was experiencing, I also converted the admin panel from a class-based to a functional component.