### PR TITLE
Remove the add member button from the admin page

### DIFF
--- a/frontend/src/containers/AdminPanel/AdminPanel.js
+++ b/frontend/src/containers/AdminPanel/AdminPanel.js
@@ -122,11 +122,6 @@ class AdminPanel extends Component {
                   Add Recipe
                 </Button>
               )}
-              {activeTab === 'users' && (
-                <Button className="admin-add-button" size="lg">
-                  Add Member
-                </Button>
-              )}
             </Nav>
             <TabContent id="bootstrap-overrides-pagination" activeTab={activeTab}>
               <TabPane tabId="recipes" className="table">


### PR DESCRIPTION
### Ticket Number:
#402 


### Describe The Problem Being Solved:
Remove the non-functional "Add Member" button from the admin page.


<img width="1409" alt="Screen Shot 2020-01-23 at 7 16 10 PM" src="https://user-images.githubusercontent.com/8541241/73037595-3d2fce80-3e15-11ea-81ee-a878abd7c010.png">

### Checklist For Submitter

* [x] I have documented all new functionality
* [x] I have screenshotted new UI changes and attached them to this PR
