### PR TITLE
Add real comment count to recipes admin page

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -40,7 +40,7 @@ class Api::V1::RecipesController < ApplicationController
     tags.each do |tag|
       db_tags << Tag.find(tag[:id])
     end
-   
+
     @recipe.tags = db_tags
     @recipe.update(rp)
   end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -15,4 +15,10 @@ class Recipe < ApplicationRecord
   belongs_to :user
   has_and_belongs_to_many :tags
   has_many :comments, -> { order('created_at DESC') }
+
+  def as_json(options = {})
+    super(options).merge({
+      'comment_count' => comments.count
+    })
+  end
 end

--- a/frontend/src/components/AdminControls/Recipes.js
+++ b/frontend/src/components/AdminControls/Recipes.js
@@ -32,12 +32,17 @@ const Recipes = ({ recipes }) => {
     </tr>
   );
 
-  const recipeRow = ({ title, user, created_at: createdAt }) => (
+  const recipeRow = ({
+    title,
+    user,
+    comment_count: commentCount,
+    created_at: createdAt,
+  }) => (
     <tr>
       <td>{title}</td>
       <td>{`${user.first_name} ${user.last_name}`}</td>
       <td>{formatDate(createdAt)}</td>
-      <td>TBD</td>
+      <td>{commentCount}</td>
       <td>{adminButtons}</td>
     </tr>
   );


### PR DESCRIPTION
### Ticket Number:
#429 


### Describe The Problem Being Solved:
Adds real comment counts to the admin page.

<img width="1562" alt="Screen Shot 2020-01-23 at 8 39 59 PM" src="https://user-images.githubusercontent.com/8541241/73040793-96512f80-3e20-11ea-8d69-6307a24be05f.png">

### Checklist For Submitter

* [x] I have documented all new functionality
* [ ] I have screenshotted new UI changes and attached them to this PR
