### PR TITLE
Fix reipes admin

### DIFF
--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -7,7 +7,6 @@ class Api::V1::RecipesController < ApplicationController
   end
 
   def index
-    puts params
     if params[:search]
       @recipes = Recipe.search(params[:search]).paginate(:page => params[:page], :per_page => 20)
     elsif params[:user_id]
@@ -72,8 +71,20 @@ class Api::V1::RecipesController < ApplicationController
     end
   end
 
-  def recipe_params
-    params.require(:recipe).permit(:title, :snippet, :difficulty, :duration, :servings, :photo, ingredients: [], tags: [:id, :title], directions: [])
-  end
+  private
 
+  def recipe_params
+    params.require(:recipe).permit(
+      :title,
+      :snippet,
+      :difficulty,
+      :duration,
+      :servings,
+      :photo,
+      :search,
+      :page,
+      ingredients: [],
+      tags: [:id, :title],
+      directions: [])
+  end
 end

--- a/frontend/src/components/AdminControls/Recipes.js
+++ b/frontend/src/components/AdminControls/Recipes.js
@@ -1,5 +1,6 @@
 import map from 'lodash/map';
 import React, { Fragment } from 'react';
+import { withRouter } from 'react-router-dom';
 import PaginatedTable from './PaginatedTable';
 import { formatDate } from '../../lib/utilities';
 import { deleteRecipe } from '../../lib/apiClient';
@@ -66,4 +67,4 @@ const Recipes = ({ history, recipes, refreshRecipes }) => {
   );
 };
 
-export default Recipes;
+export default withRouter(Recipes);

--- a/frontend/src/lib/apiClient.js
+++ b/frontend/src/lib/apiClient.js
@@ -97,10 +97,12 @@ const adminEditUser = (data, userId) => apiClient.patch(`api/v1/users/${userId}`
 // RECIPES
 
 const getRecipes = (page, search) => {
-  const query1 = search ? `search=${search}` : '';
-  const query2 = `page=${page}`;
-  return apiClient.get(`api/v1/recipes?${query1}&${query2}`)
-    .then(results => results.data);
+  const params = {};
+
+  if (page) params.page = page;
+  if (search) params.search = search;
+
+  return apiClient.get('api/v1/recipes', { params }).then(results => results.data);
 };
 
 const getRecipe = id => apiClient.get(`api/v1/recipes/${id}`);


### PR DESCRIPTION
### Ticket Number:
N/A


### Describe The Problem Being Solved:
This fixes a bug that prevented recipes from showing up on the admin page.

Namely, the issue was that when page was `undefined` in the `getRecipes` function in `apiClient`, it would pass `"undefined"` as a string for the value of page, which made our pagination gem freak out.

This also updates the recipes controller to use permitted parameters because we weren't using those for some reason.......

And it also adds the `withRouter` thing to the Recipes admin page, because without it, you were unable to redirect to the edit recipes page.
### Checklist For Submitter

* [x] I have documented all new functionality
* [x] I have screenshotted new UI changes and attached them to this PR
